### PR TITLE
* MRADEV-1020: update Dockerfile for python services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ngrefarch/python_base:3.5
+FROM python:3.5
 
 RUN useradd --create-home -s /bin/bash auth-proxy
 
@@ -24,6 +24,15 @@ ENV USE_NGINX_PLUS=${USE_NGINX_PLUS_ARG:-true} \
     GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID_ARG} \
     FACEBOOK_APP_ID=${FACEBOOK_APP_ID_ARG} \
     FACEBOOK_APP_SECRET=${FACEBOOK_SECRET_KEY_ARG}
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && apt-get install -y -q \
+    apt-transport-https \
+    libffi-dev \
+    libssl-dev \
+    lsb-release \
+    wget && \
+    cd /
 
 COPY nginx/ssl/ /etc/ssl/nginx/
 COPY ./app/ /usr/src/app


### PR DESCRIPTION
Removing a layer of abstraction because the ngrefarch/python_base repository no longer exists and we have deprecated this image in favor of a more generic image build